### PR TITLE
Move to the central Homebrew tap and automate cask updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,3 +144,60 @@ jobs:
               echo "sha256 \"$SHA\""
               echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # Keep sdenike/homebrew-tap's cask in step with the release just published.
+      # Commits straight to the tap's default branch rather than opening a pull
+      # request: a PR per release would need merging every time, which is the
+      # manual step this exists to remove. The tap's commit history is the record.
+      #
+      # Needs HOMEBREW_TAP_TOKEN — a PAT with contents:write on sdenike/homebrew-tap.
+      # The workflow's own GITHUB_TOKEN cannot write to another repository.
+      - name: Check for tap token
+        id: taptoken
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -n "${TAP_TOKEN:-}" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::HOMEBREW_TAP_TOKEN is not set — skipping the Homebrew cask update. The release itself is unaffected."
+          fi
+
+      - name: Check out the Homebrew tap
+        if: steps.taptoken.outputs.present == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: sdenike/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Bump hidden-revived cask
+        if: steps.taptoken.outputs.present == 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          ARTIFACT="dist/HiddenBarRevived-${VERSION}.zip"
+          SHA=$(/usr/bin/shasum -a 256 "$ARTIFACT" | awk '{ print $1 }')
+          CASK="homebrew-tap/Casks/hidden-revived.rb"
+          [ -f "$CASK" ] || { echo "::error::$CASK not found in the tap"; exit 1; }
+
+          /usr/bin/sed -i '' -E "s|^  version \".*\"$|  version \"${VERSION}\"|" "$CASK"
+          /usr/bin/sed -i '' -E "s|^  sha256 \".*\"$|  sha256 \"${SHA}\"|" "$CASK"
+
+          grep -q "version \"${VERSION}\"" "$CASK" || { echo "::error::version substitution failed"; exit 1; }
+          grep -q "sha256 \"${SHA}\"" "$CASK"      || { echo "::error::sha256 substitution failed"; exit 1; }
+
+          cd homebrew-tap
+          if git diff --quiet; then
+            echo "Cask already at ${VERSION}; nothing to do."
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -am "hidden-revived ${VERSION}
+
+          Released by sdenike/hidden-revived's release workflow, run ${GITHUB_RUN_ID}."
+          git push

--- a/README.md
+++ b/README.md
@@ -43,11 +43,15 @@ See [CHANGELOG.md](CHANGELOG.md) for full release notes.
 ### Homebrew
 
 ```sh
-brew tap sdenike/hidden-revived
+brew tap sdenike/tap
 brew install --cask hidden-revived
 ```
 
-The cask lives in [`sdenike/homebrew-hidden-revived`](https://github.com/sdenike/homebrew-hidden-revived) and pulls the signed + notarized `.zip` directly from this repo's GitHub Releases.
+The cask lives in [`sdenike/homebrew-tap`](https://github.com/sdenike/homebrew-tap) and pulls the signed + notarized `.zip` directly from this repo's GitHub Releases.
+
+That tap serves every one of my applications, so you only need to run `brew tap` once — anything added later installs with just `brew install --cask <name>`.
+
+> **Moved from `sdenike/homebrew-hidden-revived`.** If you tapped that repository before August 2026, run `brew untap sdenike/hidden-revived` and then the two commands above.
 
 ### Mac App Store
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -35,14 +35,17 @@ manual to do beyond keeping Xcode current. The CI workflow runs on
    ```bash
    shasum -a 256 HiddenBarRevived-2.0.x.zip
    ```
-4. **Update the Homebrew tap** — edit `Casks/hidden-revived.rb` in
-   `github.com/sdenike/homebrew-hidden-revived`:
-   ```ruby
-   version "2.0.x"
-   sha256 "<new-sha256>"
-   ```
-   Commit, push to `main`. Users on `brew upgrade --cask hidden-revived`
-   will pick it up on their next run.
+4. **The Homebrew cask updates itself.** The release workflow rewrites `version`
+   and `sha256` in `Casks/hidden-revived.rb` in
+   [`sdenike/homebrew-tap`](https://github.com/sdenike/homebrew-tap) and commits
+   there, so there is nothing to edit by hand. Users pick it up on their next
+   `brew upgrade --cask hidden-revived`.
+
+   This needs a `HOMEBREW_TAP_TOKEN` secret on this repository — a PAT with
+   `contents: write` on `sdenike/homebrew-tap`. A workflow's built-in
+   `GITHUB_TOKEN` is scoped to its own repository and cannot push to the tap. If
+   the secret is missing the step warns and succeeds, so the release itself is
+   never blocked by it.
 
 ## Local-only signing (without GitHub Actions)
 


### PR DESCRIPTION
Closes #3.

Hidden Bar Revived was distributed through its own tap, `sdenike/homebrew-hidden-revived`. That pattern means a tap repository per application, and a separate `brew tap` for users each time.

The cask now lives in [`sdenike/homebrew-tap`](https://github.com/sdenike/homebrew-tap) alongside every other app:

```sh
brew tap sdenike/tap
brew install --cask hidden-revived
```

The cask itself was carried over **unchanged** — same version, checksum, livecheck and zap stanzas. Only its location moved.

## What changed here

- **README** — new tap instructions, plus a note telling anyone on the old tap to `brew untap sdenike/hidden-revived` first.
- **docs/RELEASING.md** — step 4 was "edit `Casks/hidden-revived.rb` by hand, commit, push". That step is gone; the cask updates itself.
- **release.yml** — previously it only *printed* the version and sha256 to the job summary for someone to paste into the cask. It now rewrites them in the tap and commits.

## Automation notes

It commits directly to the tap rather than opening a pull request: a PR per release would need merging every time, which is the manual step this removes. The tap's commit history is the audit trail.

Two safeguards: it verifies both substitutions landed (`grep`) before committing rather than trusting `sed`, and it checks for `HOMEBREW_TAP_TOKEN` first — if absent it warns and succeeds, so a missing token can never fail an otherwise-good release.

## Prerequisite

`HOMEBREW_TAP_TOKEN` must be set on this repository: a PAT with `contents: write` on `sdenike/homebrew-tap`. A workflow's built-in `GITHUB_TOKEN` cannot push to another repository.

## Existing users

Retiring `sdenike/homebrew-hidden-revived` breaks `brew upgrade` for anyone who tapped it. Confirmed with the maintainer that adoption is low enough for this to be acceptable, so the old tap is being removed rather than left in place with a deprecation notice. The README documents the `untap` step regardless.

## Verification

`brew audit --cask sdenike/tap/hidden-revived` is clean against the real tap, and `brew info` resolves it correctly from the new location.